### PR TITLE
Hight tracking

### DIFF
--- a/Ascendia/Assets/Scripts/FloorTracking.cs
+++ b/Ascendia/Assets/Scripts/FloorTracking.cs
@@ -8,6 +8,9 @@ public class FloorTracking : MonoBehaviour
     private int currentFloor = 0;
     private Transform playerTransform;
     private float previousPlayerY;
+    private bool isInCollider = false;
+
+    private const float minPlayerHeightIncrease = 5f;
 
     private void Start()
     {
@@ -25,41 +28,32 @@ public class FloorTracking : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-        UnityEngine.Debug.LogError("Collision detected");
-        if (other.CompareTag("Platform") && playerTransform != null)
+        if (other.CompareTag("Platform"))
         {
-            // Check if the player has moved up by at least 5 units
-            float playerHeightIncrease = playerTransform.position.y - previousPlayerY;
-            UnityEngine.Debug.LogError("Player height increase: " + playerHeightIncrease);
-            UnityEngine.Debug.LogError("Current player Y: " + playerTransform.position.y);
-            UnityEngine.Debug.LogError("Previous player Y: " + previousPlayerY);
-            if (playerTransform.position.y - previousPlayerY >= 4f)
-            {
-                previousPlayerY = playerTransform.position.y;
-                currentFloor++;
-    
-                UnityEngine.Debug.LogError("Current floor: " + currentFloor);
+            isInCollider = true;
+        }
+    }
 
-            }
+    private void OnTriggerExit2D(Collider2D other)
+    {
+        if (other.CompareTag("Platform"))
+        {
+            isInCollider = false;
         }
     }
 
     private void Update()
     {
-        if (playerTransform != null)
+        if (playerTransform != null && !isInCollider)
         {
-            previousPlayerY = playerTransform.position.y;
+            float playerHeightIncrease = playerTransform.position.y - previousPlayerY;
+            if (playerHeightIncrease >= minPlayerHeightIncrease)
+            {
+                //currentFloor = playerTransform.position.y % 5f;
+                currentFloor++;
+                UnityEngine.Debug.LogError("Current floor: " + currentFloor);
+                previousPlayerY = playerTransform.position.y;
+            }
         }
     }
 }
-
-
-/* private void OnTriggerExit2D(Collider2D other)
- {
-     if (other.CompareTag("Platform"))
-     {
-         currentFloor--;
-         UnityEngine.Debug.Log("Current floor: " + currentFloor);
-     }
- } */
-

--- a/Ascendia/Assets/Scripts/FloorTracking.cs
+++ b/Ascendia/Assets/Scripts/FloorTracking.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using UnityEngine;
 
+/*
+
 public class FloorTracking : MonoBehaviour
 {
     private int currentFloor = 0;
@@ -39,10 +41,9 @@ public class FloorTracking : MonoBehaviour
             }
         }
     }
-}
+} */
 
 
-/* using UnityEngine;
 
 public class FloorTracking : MonoBehaviour
 {
@@ -96,4 +97,4 @@ public class FloorTracking : MonoBehaviour
             }
         }
     }
-} */
+}

--- a/Ascendia/Assets/Scripts/FloorTracking.cs
+++ b/Ascendia/Assets/Scripts/FloorTracking.cs
@@ -1,26 +1,65 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using UnityEngine;
 
 public class FloorTracking : MonoBehaviour
 {
     private int currentFloor = 0;
+    private Transform playerTransform;
+    private float previousPlayerY;
 
-    private void OnTriggerEnter2D(Collider2D other)
+    private void Start()
     {
-        if (other.CompareTag("Platform"))
+        GameObject player = GameObject.FindGameObjectWithTag("Player");
+        if (player != null)
         {
-            currentFloor++;
-            UnityEngine.Debug.Log("Current floor: " + currentFloor);
+            playerTransform = player.transform;
+            previousPlayerY = playerTransform.position.y;
+        }
+        else
+        {
+            UnityEngine.Debug.LogError("Player object not found.");
         }
     }
 
-    /* private void OnTriggerExit2D(Collider2D other)
-     {
-         if (other.CompareTag("Platform"))
-         {
-             currentFloor--;
-             UnityEngine.Debug.Log("Current floor: " + currentFloor);
-         }
-     } */
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        UnityEngine.Debug.LogError("Collision detected");
+        if (other.CompareTag("Platform") && playerTransform != null)
+        {
+            // Check if the player has moved up by at least 5 units
+            float playerHeightIncrease = playerTransform.position.y - previousPlayerY;
+            UnityEngine.Debug.LogError("Player height increase: " + playerHeightIncrease);
+            UnityEngine.Debug.LogError("Current player Y: " + playerTransform.position.y);
+            UnityEngine.Debug.LogError("Previous player Y: " + previousPlayerY);
+            if (playerTransform.position.y - previousPlayerY >= 4f)
+            {
+                previousPlayerY = playerTransform.position.y;
+                currentFloor++;
+    
+                UnityEngine.Debug.LogError("Current floor: " + currentFloor);
+
+            }
+        }
+    }
+
+    private void Update()
+    {
+        if (playerTransform != null)
+        {
+            previousPlayerY = playerTransform.position.y;
+        }
+    }
 }
+
+
+/* private void OnTriggerExit2D(Collider2D other)
+ {
+     if (other.CompareTag("Platform"))
+     {
+         currentFloor--;
+         UnityEngine.Debug.Log("Current floor: " + currentFloor);
+     }
+ } */
+

--- a/Ascendia/Assets/Scripts/FloorTracking.cs
+++ b/Ascendia/Assets/Scripts/FloorTracking.cs
@@ -8,7 +8,7 @@ public class FloorTracking : MonoBehaviour
     private int currentFloor = 0;
     private Transform playerTransform;
     private float previousPlayerY;
-    private bool isInCollider = false;
+    private bool isInCollider = true;
 
     private const float minPlayerHeightIncrease = 5f;
 
@@ -28,7 +28,7 @@ public class FloorTracking : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-        if (other.CompareTag("Platform") && other.GetType() == typeof(BoxCollider2D))
+        if (other.CompareTag("Platform"))
         {
             isInCollider = true;
         }
@@ -36,7 +36,7 @@ public class FloorTracking : MonoBehaviour
 
     private void OnTriggerExit2D(Collider2D other)
     {
-        if (other.CompareTag("Platform") && other.GetType() == typeof(BoxCollider2D))
+        if (other.CompareTag("Platform"))
         {
             isInCollider = false;
         }

--- a/Ascendia/Assets/Scripts/FloorTracking.cs
+++ b/Ascendia/Assets/Scripts/FloorTracking.cs
@@ -49,8 +49,7 @@ public class FloorTracking : MonoBehaviour
             float playerHeightIncrease = playerTransform.position.y - previousPlayerY;
             if (playerHeightIncrease >= minPlayerHeightIncrease)
             {
-                //currentFloor = playerTransform.position.y % 5f;
-                currentFloor++;
+                currentFloor += Mathf.FloorToInt(playerHeightIncrease / minPlayerHeightIncrease);
                 UnityEngine.Debug.LogError("Current floor: " + currentFloor);
                 previousPlayerY = playerTransform.position.y;
             }

--- a/Ascendia/Assets/Scripts/FloorTracking.cs
+++ b/Ascendia/Assets/Scripts/FloorTracking.cs
@@ -6,6 +6,47 @@ using UnityEngine;
 public class FloorTracking : MonoBehaviour
 {
     private int currentFloor = 0;
+    private Rigidbody2D playerRigidbody;
+    private float previousPlayerY;
+
+    private const float minPlayerHeightIncrease = 5f;
+    private const float stationaryThreshold = 0.5f; // Threshhold for stationary trigger speed
+
+    private void Start()
+    {
+        GameObject player = GameObject.FindGameObjectWithTag("Player");
+        if (player != null)
+        {
+            playerRigidbody = player.GetComponent<Rigidbody2D>();
+            previousPlayerY = player.transform.position.y;
+        }
+        else
+        {
+            UnityEngine.Debug.LogError("Player object not found.");
+        }
+    }
+
+    private void Update()
+    {
+        if (playerRigidbody != null && Mathf.Abs(playerRigidbody.velocity.y) < stationaryThreshold)
+        {
+            float playerHeightIncrease = playerRigidbody.position.y - previousPlayerY;
+            if (playerHeightIncrease >= minPlayerHeightIncrease)
+            {
+                currentFloor++;
+                UnityEngine.Debug.Log("Current floor: " + currentFloor);
+                previousPlayerY = playerRigidbody.position.y;
+            }
+        }
+    }
+}
+
+
+/* using UnityEngine;
+
+public class FloorTracking : MonoBehaviour
+{
+    private int currentFloor = 0;
     private Transform playerTransform;
     private float previousPlayerY;
     private bool isInCollider = true;
@@ -55,4 +96,4 @@ public class FloorTracking : MonoBehaviour
             }
         }
     }
-} 
+} */

--- a/Ascendia/Assets/Scripts/FloorTracking.cs
+++ b/Ascendia/Assets/Scripts/FloorTracking.cs
@@ -28,7 +28,7 @@ public class FloorTracking : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-        if (other.CompareTag("Platform"))
+        if (other.CompareTag("Platform") && other.GetType() == typeof(BoxCollider2D))
         {
             isInCollider = true;
         }
@@ -36,7 +36,7 @@ public class FloorTracking : MonoBehaviour
 
     private void OnTriggerExit2D(Collider2D other)
     {
-        if (other.CompareTag("Platform"))
+        if (other.CompareTag("Platform") && other.GetType() == typeof(BoxCollider2D))
         {
             isInCollider = false;
         }

--- a/Ascendia/Assets/Scripts/FloorTracking.cs
+++ b/Ascendia/Assets/Scripts/FloorTracking.cs
@@ -97,4 +97,4 @@ public class FloorTracking : MonoBehaviour
             }
         }
     }
-}
+} 

--- a/Ascendia/Assets/Scripts/FloorTracking.cs
+++ b/Ascendia/Assets/Scripts/FloorTracking.cs
@@ -50,9 +50,9 @@ public class FloorTracking : MonoBehaviour
             if (playerHeightIncrease >= minPlayerHeightIncrease)
             {
                 currentFloor += Mathf.FloorToInt(playerHeightIncrease / minPlayerHeightIncrease);
-                UnityEngine.Debug.LogError("Current floor: " + currentFloor);
+                UnityEngine.Debug.Log("Current floor: " + currentFloor);
                 previousPlayerY = playerTransform.position.y;
             }
         }
     }
-}
+} 

--- a/Ascendia/Assets/Scripts/PlayerMovement.cs
+++ b/Ascendia/Assets/Scripts/PlayerMovement.cs
@@ -22,7 +22,7 @@ public class PlayerMovement : MonoBehaviour
 
     private float horizontalInput;
     private bool isJumping;
-    private bool isGrounded;
+    public bool isGrounded;
     private float currentSpeed;
 
     private void Update()


### PR DESCRIPTION
Height tracking for traversing the tower.

- Various checks for the player model to see the y-distance traveled.
- Includes interaction with box colliders. (This should probably be changed, so it acts based upon being stationary, because currently the player can jump to the height of a Platform and interact with the box collider, but not actually stand on the platform to increase the "height". This technically doesn't affect the overall score, but the player can gain a +1 to highscore even if they never actually landed on the platform)